### PR TITLE
Add Polotno renderer example

### DIFF
--- a/examples/01-react/package.json
+++ b/examples/01-react/package.json
@@ -24,7 +24,8 @@
     "react-konva": "18.2.10",
     "konva": "9.3.20",
     "canvas": "^3.1.1",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "polotno": "^2.24.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.14"

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -1,0 +1,65 @@
+import { observer } from '@rekajs/react';
+import * as t from '@rekajs/types';
+import * as React from 'react';
+import { createStore } from 'polotno/model/store';
+import { Workspace } from 'polotno/canvas/workspace';
+
+const store = createStore({ key: 'reka-demo', showCredit: false });
+
+export type PolotnoRendererProps = {
+  view: t.View;
+};
+
+export const PolotnoRenderer = observer(({ view }: PolotnoRendererProps) => {
+  React.useEffect(() => {
+    store.clear();
+    const page = store.addPage();
+
+    let yCursor = 0;
+    const nextY = () => {
+      const y = yCursor;
+      yCursor += 20;
+      return y;
+    };
+
+    const renderView = (v: t.View) => {
+      if (v.type === 'TagView') {
+        const props = (v as any).props || {};
+        if (v.tag === 'text') {
+          page.addElement({
+            type: 'text',
+            text: String(props.value ?? ''),
+            x: 0,
+            y: nextY(),
+            fill: props.color ?? 'black',
+            fontSize: props.fontSize ?? 16,
+          });
+        } else if (v.tag === 'rect') {
+          page.addElement({
+            type: 'figure',
+            subType: 'rect',
+            x: props.x ?? 0,
+            y: props.y ?? 0,
+            width: props.width ?? 0,
+            height: props.height ?? 0,
+            fill: props.color ?? 'black',
+          });
+        } else {
+          (v as any).children?.forEach(renderView);
+        }
+      } else if (v.type === 'RekaComponentView' || v.type === 'ExternalComponentView') {
+        (v as any).render.forEach(renderView);
+      } else if (
+        v.type === 'FrameView' ||
+        v.type === 'SlotView' ||
+        v.type === 'FragmentView'
+      ) {
+        (v as any).children.forEach(renderView);
+      }
+    };
+
+    renderView(view);
+  }, [view]);
+
+  return <Workspace store={store} />;
+});

--- a/examples/01-react/src/pages/polotno.tsx
+++ b/examples/01-react/src/pages/polotno.tsx
@@ -1,0 +1,129 @@
+import { Reka } from '@rekajs/core';
+import { RekaProvider, observer } from '@rekajs/react';
+import * as t from '@rekajs/types';
+import * as React from 'react';
+
+import { Editor } from '@/components/Editor';
+
+import dynamic from 'next/dynamic';
+
+const PolotnoRenderer = dynamic(
+  () => import('@/components/PolotnoRenderer').then((m) => m.PolotnoRenderer),
+  { ssr: false }
+);
+
+const reka = Reka.create();
+
+reka.load(
+  t.state({
+    program: t.program({
+      globals: [
+        t.val({ name: 'globalText', init: t.literal({ value: 'Global Text!' }) }),
+      ],
+      components: [
+        t.rekaComponent({
+          name: 'App',
+          props: [],
+          state: [],
+          template: t.tagTemplate({
+            tag: 'div',
+            props: {
+              className: t.literal({
+                value: 'bg-neutral-100 px-3 py-4 w-full h-full',
+              }),
+            },
+            children: [
+              t.tagTemplate({
+                tag: 'h4',
+                props: { className: t.literal({ value: 'text-lg w-full' }) },
+                children: [
+                  t.tagTemplate({
+                    tag: 'text',
+                    props: { value: t.literal({ value: 'Hello World' }) },
+                    children: [],
+                  }),
+                ],
+              }),
+              t.componentTemplate({
+                component: t.identifier({ name: 'Button' }),
+                props: {},
+                children: [],
+              }),
+            ],
+          }),
+        }),
+        t.rekaComponent({
+          name: 'Button',
+          props: [
+            t.componentProp({
+              name: 'text',
+              init: t.literal({ value: 'Click me!' }),
+            }),
+          ],
+          state: [t.val({ name: 'counter', init: t.literal({ value: 0 }) })],
+          template: t.tagTemplate({
+            tag: 'button',
+            props: {
+              className: t.literal({ value: 'rounded border-2 px-3 py-2' }),
+              onClick: t.func({
+                params: [],
+                body: t.block({
+                  statements: [
+                    t.assignment({
+                      left: t.identifier({ name: 'counter' }),
+                      operator: '+=',
+                      right: t.literal({ value: 1 }),
+                    }),
+                  ],
+                }),
+              }),
+            },
+            children: [
+              t.tagTemplate({
+                tag: 'text',
+                props: { value: t.identifier({ name: 'text' }) },
+                children: [],
+              }),
+              t.tagTemplate({
+                tag: 'text',
+                props: {
+                  value: t.binaryExpression({
+                    left: t.literal({ value: ' -> ' }),
+                    operator: '+',
+                    right: t.identifier({ name: 'counter' }),
+                  }),
+                },
+                children: [],
+              }),
+            ],
+          }),
+        }),
+      ],
+    }),
+  })
+);
+
+const frame = reka.createFrame({
+  id: 'Polotno Demo',
+  component: { name: 'App' },
+});
+frame.compute(true);
+
+const PolotnoView = observer(() => {
+  return frame.view ? <PolotnoRenderer view={frame.view} /> : null;
+});
+
+export default function PolotnoPage() {
+  return (
+    <RekaProvider reka={reka}>
+      <div className="flex h-screen">
+        <div className="w-3/6 h-full border-r-2">
+          <Editor />
+        </div>
+        <div className="flex-1 flex items-center justify-center">
+          <PolotnoView />
+        </div>
+      </div>
+    </RekaProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add Polotno dependency to the React example
- implement `PolotnoRenderer` component
- create a `polotno` demo page that uses the new renderer

## Testing
- `pnpm test` *(fails: Failed to resolve entry for package)*

------
https://chatgpt.com/codex/tasks/task_b_685974f9f238832c80a6849f4114d14c