### PR TITLE
Add Polotno–Reka sync example

### DIFF
--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -35,55 +35,60 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
         const props = (v as any).props || {};
         const tplId = v.template.id;
         const viewKey = (v as any).key ?? tplId;
-        activeViewKeys.add(viewKey);
-        let el = existing[viewKey];
 
-        if (!el) {
-          if (v.tag === 'text') {
-            el = page.addElement({
-              type: 'text',
-              text: String(props.value ?? ''),
-              x: props.x ?? 0,
-              y: props.y ?? 0,
-              fill: props.color ?? 'black',
-              fontSize: props.fontSize ?? 16,
-              custom: { rekaTplId: tplId, rekaViewKey: viewKey },
+        if (v.tag === 'text' || v.tag === 'rect') {
+          activeViewKeys.add(viewKey);
+          let el = existing[viewKey];
+
+          if (!el) {
+            if (v.tag === 'text') {
+              el = page.addElement({
+                type: 'text',
+                text: String(props.value ?? ''),
+                x: props.x ?? 0,
+                y: props.y ?? 0,
+                fill: props.color ?? 'black',
+                fontSize: props.fontSize ?? 16,
+                custom: { rekaTplId: tplId, rekaViewKey: viewKey },
+              });
+            } else if (v.tag === 'rect') {
+              el = page.addElement({
+                type: 'figure',
+                subType: 'rect',
+                x: props.x ?? 0,
+                y: props.y ?? 0,
+                width: props.width ?? 0,
+                height: props.height ?? 0,
+                fill: props.color ?? 'black',
+                custom: { rekaTplId: tplId, rekaViewKey: viewKey },
+              });
+            }
+          } else {
+            el.set({
+              x: props.x ?? el.x,
+              y: props.y ?? el.y,
+              width: props.width ?? el.width,
+              height: props.height ?? el.height,
+              rotation: props.rotation ?? el.rotation,
+              visible: props.visible ?? el.visible,
             });
-          } else if (v.tag === 'rect') {
-            el = page.addElement({
-              type: 'figure',
-              subType: 'rect',
-              x: props.x ?? 0,
-              y: props.y ?? 0,
-              width: props.width ?? 0,
-              height: props.height ?? 0,
-              fill: props.color ?? 'black',
-              custom: { rekaTplId: tplId, rekaViewKey: viewKey },
+            if (v.tag === 'text') {
+              el.set({
+                text: String(props.value ?? ''),
+                fontSize: props.fontSize ?? el.fontSize,
+                fill: props.color ?? el.fill,
+              });
+            }
+            el.set({
+              custom: {
+                ...(el as any).custom,
+                rekaTplId: tplId,
+                rekaViewKey: viewKey,
+              },
             });
           }
         } else {
-          el.set({
-            x: props.x ?? el.x,
-            y: props.y ?? el.y,
-            width: props.width ?? el.width,
-            height: props.height ?? el.height,
-            rotation: props.rotation ?? el.rotation,
-            visible: props.visible ?? el.visible,
-          });
-          if (v.tag === 'text') {
-            el.set({
-              text: String(props.value ?? ''),
-              fontSize: props.fontSize ?? el.fontSize,
-              fill: props.color ?? el.fill,
-            });
-          }
-          el.set({
-            custom: {
-              ...(el as any).custom,
-              rekaTplId: tplId,
-              rekaViewKey: viewKey,
-            },
-          });
+          (v as any).children?.forEach(renderView);
         }
       } else if (
         v.type === 'RekaComponentView' ||

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -13,7 +13,9 @@ export type PolotnoRendererProps = {
 };
 
 export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
+  const updatingFromRekaRef = React.useRef(false);
   React.useEffect(() => {
+    updatingFromRekaRef.current = true;
     store.clear();
     const page = store.addPage();
 
@@ -65,6 +67,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
     if (frame.view) {
       renderView(frame.view);
     }
+    updatingFromRekaRef.current = false;
   }, [frame.view]);
 
   React.useEffect(() => {
@@ -73,6 +76,9 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
       () =>
         store.activePage?.children.map((el) => ({
           id: el.id,
+          type: (el as any).type,
+          subType: (el as any).subType,
+          text: (el as any).text,
           x: el.x,
           y: el.y,
           width: el.width,
@@ -82,11 +88,48 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
           rekaTplId: (el as any).custom?.rekaTplId,
         })),
       (elements) => {
+        if (updatingFromRekaRef.current) return;
         frame.reka.change(() => {
           elements.forEach((el) => {
-            if (!el.rekaTplId) return;
-            const tpl = frame.reka.getNodeFromId(el.rekaTplId, t.TagTemplate);
+            let tpl =
+              el.rekaTplId &&
+              frame.reka.getNodeFromId(el.rekaTplId, t.TagTemplate);
+            const appComponent = frame.reka.state.program.components.find(
+              (c) => c.name === frame.componentName
+            );
+            const rootTpl = appComponent?.template as t.TagTemplate | undefined;
+
+            if (!tpl) {
+              if (!rootTpl) return;
+              if (el.type === 'text') {
+                tpl = t.tagTemplate({
+                  id: el.rekaTplId,
+                  tag: 'text',
+                  props: {
+                    value: t.literal({ value: el.text ?? '' }),
+                  },
+                  children: [],
+                });
+              } else if (el.type === 'figure' && el.subType === 'rect') {
+                tpl = t.tagTemplate({
+                  id: el.rekaTplId,
+                  tag: 'rect',
+                  props: {},
+                  children: [],
+                });
+              }
+
+              if (tpl) {
+                rootTpl.children.push(tpl);
+                (el as any).custom = {
+                  ...(el as any).custom,
+                  rekaTplId: tpl.id,
+                };
+              }
+            }
+
             if (!tpl) return;
+
             tpl.props = {
               ...tpl.props,
               x: t.literal({ value: el.x }),
@@ -108,6 +151,13 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
                   ? t.literal({ value: el.visible })
                   : tpl.props?.visible,
             };
+
+            if (tpl.tag === 'text') {
+              tpl.props = {
+                ...tpl.props,
+                value: t.literal({ value: el.text ?? '' }),
+              };
+            }
           });
         });
       },

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -116,17 +116,20 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
     const disposer = reaction(
       () =>
         store.activePage?.children.map((el) => ({
-          id: el.id,
-          type: (el as any).type,
-          subType: (el as any).subType,
-          text: (el as any).text,
-          x: el.x,
-          y: el.y,
-          width: el.width,
-          height: el.height,
-          rotation: el.rotation,
-          visible: el.visible,
-          rekaTplId: (el as any).custom?.rekaTplId,
+          el,
+          snapshot: {
+            id: el.id,
+            type: (el as any).type,
+            subType: (el as any).subType,
+            text: (el as any).text,
+            x: el.x,
+            y: el.y,
+            width: el.width,
+            height: el.height,
+            rotation: el.rotation,
+            visible: el.visible,
+            rekaTplId: (el as any).custom?.rekaTplId,
+          },
         })),
       (elements) => {
         if (updatingFromRekaRef.current) return;
@@ -138,49 +141,63 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
           const rootTpl = appComponent?.template as t.TagTemplate | undefined;
           const seen = new Set<string>();
 
-          elements.forEach((el) => {
+          const usedTplIds = new Set<string>();
+
+          elements.forEach(({ el, snapshot }) => {
             let tpl =
-              el.rekaTplId && frame.reka.getNodeFromId(el.rekaTplId, t.TagTemplate);
+              snapshot.rekaTplId &&
+              !usedTplIds.has(snapshot.rekaTplId) &&
+              frame.reka.getNodeFromId(snapshot.rekaTplId, t.TagTemplate);
 
             if (!tpl && rootTpl) {
-              if (el.type === 'text') {
+              if (snapshot.type === 'text') {
                 tpl = t.tagTemplate({
                   tag: 'text',
-                  props: { value: t.literal({ value: el.text ?? '' }) },
+                  props: { value: t.literal({ value: snapshot.text ?? '' }) },
                   children: [],
                 });
-              } else if (el.type === 'figure' && el.subType === 'rect') {
+              } else if (snapshot.type === 'figure' && snapshot.subType === 'rect') {
                 tpl = t.tagTemplate({ tag: 'rect', props: {}, children: [] });
               }
               if (tpl) {
                 rootTpl.children.push(tpl);
-                (el as any).custom = { ...(el as any).custom, rekaTplId: tpl.id };
+                el.set({ custom: { ...(el as any).custom, rekaTplId: tpl.id } });
               }
             }
 
             if (!tpl) return;
 
+            usedTplIds.add(tpl.id);
+
             tpl.props = {
               ...tpl.props,
-              x: t.literal({ value: el.x }),
-              y: t.literal({ value: el.y }),
-              width: el.width !== undefined ? t.literal({ value: el.width }) : tpl.props?.width,
-              height: el.height !== undefined ? t.literal({ value: el.height }) : tpl.props?.height,
+              x: t.literal({ value: snapshot.x }),
+              y: t.literal({ value: snapshot.y }),
+              width:
+                snapshot.width !== undefined
+                  ? t.literal({ value: snapshot.width })
+                  : tpl.props?.width,
+              height:
+                snapshot.height !== undefined
+                  ? t.literal({ value: snapshot.height })
+                  : tpl.props?.height,
               rotation:
-                el.rotation !== undefined
-                  ? t.literal({ value: el.rotation })
+                snapshot.rotation !== undefined
+                  ? t.literal({ value: snapshot.rotation })
                   : tpl.props?.rotation,
               visible:
-                el.visible !== undefined
-                  ? t.literal({ value: el.visible })
+                snapshot.visible !== undefined
+                  ? t.literal({ value: snapshot.visible })
                   : tpl.props?.visible,
             };
             if (tpl.tag === 'text') {
               tpl.props = {
                 ...tpl.props,
-                value: t.literal({ value: el.text ?? '' }),
+                value: t.literal({ value: snapshot.text ?? '' }),
                 fontSize:
-                  el.fontSize !== undefined ? t.literal({ value: el.fontSize }) : tpl.props?.fontSize,
+                  (snapshot as any).fontSize !== undefined
+                    ? t.literal({ value: (snapshot as any).fontSize })
+                    : tpl.props?.fontSize,
               } as any;
             }
             seen.add(tpl.id);

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -229,27 +229,29 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
           });
 
           if (rootTpl) {
-            const filterTpl = (tpl: t.Template): boolean => {
+            const prune = (tpl: t.Template): boolean => {
               if (
                 t.TagTemplate.is(tpl) &&
-                (tpl.tag === 'text' || tpl.tag === 'rect') &&
-                !seen.has(tpl.id)
+                (tpl.tag === 'text' || tpl.tag === 'rect')
               ) {
-                return false;
+                return seen.has(tpl.id);
               }
 
               if (t.SlottableTemplate.is(tpl)) {
-                tpl.children = tpl.children.filter(filterTpl);
+                tpl.children = tpl.children.filter(prune);
 
                 Object.keys(tpl.slots).forEach((slot) => {
-                  tpl.slots[slot] = tpl.slots[slot].filter(filterTpl);
+                  tpl.slots[slot] = tpl.slots[slot].filter(prune);
                 });
               }
 
               return true;
             };
 
-            filterTpl(rootTpl);
+            rootTpl.children = rootTpl.children.filter(prune);
+            Object.keys(rootTpl.slots).forEach((slot) => {
+              rootTpl.slots[slot] = rootTpl.slots[slot].filter(prune);
+            });
           }
         });
         updatingFromPolotnoRef.current = false;

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -82,6 +82,10 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
                 fontSize: props.fontSize ?? el.fontSize,
                 fill: props.color ?? el.fill,
               });
+            } else if (v.tag === 'rect') {
+              el.set({
+                fill: props.color ?? el.fill,
+              });
             }
             el.set({
               custom: {
@@ -158,6 +162,8 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
             height: el.height,
             rotation: el.rotation,
             visible: el.visible,
+            fill: (el as any).fill,
+            fontSize: (el as any).fontSize,
             rekaTplId: idMapRef.current.get(el.id) || (el as any).custom?.rekaTplId,
           },
         })),
@@ -186,14 +192,27 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
               if (snapshot.type === 'text') {
                 tpl = t.tagTemplate({
                   tag: 'text',
-                  props: { value: t.literal({ value: snapshot.text ?? '' }) },
+                  props: {
+                    value: t.literal({ value: snapshot.text ?? '' }),
+                    color: t.literal({ value: snapshot.fill ?? 'black' }),
+                    fontSize:
+                      snapshot.fontSize !== undefined
+                        ? t.literal({ value: snapshot.fontSize })
+                        : undefined,
+                  },
                   children: [],
                 });
               } else if (
                 snapshot.type === 'figure' &&
                 snapshot.subType === 'rect'
               ) {
-                tpl = t.tagTemplate({ tag: 'rect', props: {}, children: [] });
+                tpl = t.tagTemplate({
+                  tag: 'rect',
+                  props: {
+                    color: t.literal({ value: snapshot.fill ?? 'black' }),
+                  },
+                  children: [],
+                });
               }
               if (tpl) {
                 rootTpl.children.push(tpl);
@@ -228,7 +247,11 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
                 snapshot.visible !== undefined
                   ? t.literal({ value: snapshot.visible })
                   : tpl.props?.visible,
-            };
+              color:
+                snapshot.fill !== undefined
+                  ? t.literal({ value: snapshot.fill })
+                  : tpl.props?.color,
+            } as any;
             if (tpl.tag === 'text') {
               tpl.props = {
                 ...tpl.props,

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -1,16 +1,18 @@
 import { observer } from '@rekajs/react';
 import * as t from '@rekajs/types';
 import * as React from 'react';
+import { Frame } from '@rekajs/core';
+import { reaction, comparer } from 'mobx';
 import { createStore } from 'polotno/model/store';
 import { Workspace } from 'polotno/canvas/workspace';
 
 const store = createStore({ key: 'reka-demo', showCredit: false });
 
 export type PolotnoRendererProps = {
-  view: t.View;
+  frame: Frame;
 };
 
-export const PolotnoRenderer = observer(({ view }: PolotnoRendererProps) => {
+export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
   React.useEffect(() => {
     store.clear();
     const page = store.addPage();
@@ -33,6 +35,7 @@ export const PolotnoRenderer = observer(({ view }: PolotnoRendererProps) => {
             y: nextY(),
             fill: props.color ?? 'black',
             fontSize: props.fontSize ?? 16,
+            custom: { rekaTplId: v.template.id },
           });
         } else if (v.tag === 'rect') {
           page.addElement({
@@ -43,6 +46,7 @@ export const PolotnoRenderer = observer(({ view }: PolotnoRendererProps) => {
             width: props.width ?? 0,
             height: props.height ?? 0,
             fill: props.color ?? 'black',
+            custom: { rekaTplId: v.template.id },
           });
         } else {
           (v as any).children?.forEach(renderView);
@@ -58,8 +62,59 @@ export const PolotnoRenderer = observer(({ view }: PolotnoRendererProps) => {
       }
     };
 
-    renderView(view);
-  }, [view]);
+    if (frame.view) {
+      renderView(frame.view);
+    }
+  }, [frame.view]);
+
+  React.useEffect(() => {
+    if (!frame) return;
+    const disposer = reaction(
+      () =>
+        store.activePage?.children.map((el) => ({
+          id: el.id,
+          x: el.x,
+          y: el.y,
+          width: el.width,
+          height: el.height,
+          rotation: el.rotation,
+          visible: el.visible,
+          rekaTplId: (el as any).custom?.rekaTplId,
+        })),
+      (elements) => {
+        frame.reka.change(() => {
+          elements.forEach((el) => {
+            if (!el.rekaTplId) return;
+            const tpl = frame.reka.getNodeFromId(el.rekaTplId, t.TagTemplate);
+            if (!tpl) return;
+            tpl.props = {
+              ...tpl.props,
+              x: t.literal({ value: el.x }),
+              y: t.literal({ value: el.y }),
+              width:
+                el.width !== undefined
+                  ? t.literal({ value: el.width })
+                  : tpl.props?.width,
+              height:
+                el.height !== undefined
+                  ? t.literal({ value: el.height })
+                  : tpl.props?.height,
+              rotation:
+                el.rotation !== undefined
+                  ? t.literal({ value: el.rotation })
+                  : tpl.props?.rotation,
+              visible:
+                el.visible !== undefined
+                  ? t.literal({ value: el.visible })
+                  : tpl.props?.visible,
+            };
+          });
+        });
+      },
+      { equals: comparer.structural }
+    );
+    return () => disposer();
+  }, [frame]);
 
   return <Workspace store={store} />;
 });

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -229,9 +229,27 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
           });
 
           if (rootTpl) {
-            rootTpl.children = rootTpl.children.filter((child) =>
-              seen.has(child.id)
-            );
+            const filterTpl = (tpl: t.Template): boolean => {
+              if (
+                t.TagTemplate.is(tpl) &&
+                (tpl.tag === 'text' || tpl.tag === 'rect') &&
+                !seen.has(tpl.id)
+              ) {
+                return false;
+              }
+
+              if (t.SlottableTemplate.is(tpl)) {
+                tpl.children = tpl.children.filter(filterTpl);
+
+                Object.keys(tpl.slots).forEach((slot) => {
+                  tpl.slots[slot] = tpl.slots[slot].filter(filterTpl);
+                });
+              }
+
+              return true;
+            };
+
+            filterTpl(rootTpl);
           }
         });
         updatingFromPolotnoRef.current = false;

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -1,7 +1,7 @@
 import { observer } from '@rekajs/react';
+import { Frame } from '@rekajs/core';
 import * as t from '@rekajs/types';
 import * as React from 'react';
-import { Frame } from '@rekajs/core';
 import { reaction, comparer } from 'mobx';
 import { createStore } from 'polotno/model/store';
 import { Workspace } from 'polotno/canvas/workspace';
@@ -15,52 +15,71 @@ export type PolotnoRendererProps = {
 export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
   const updatingFromRekaRef = React.useRef(false);
   const updatingFromPolotnoRef = React.useRef(false);
-  const renderFrame = React.useCallback(() => {
-    updatingFromRekaRef.current = true;
-    store.clear();
-    const page = store.addPage();
 
-    let yCursor = 0;
-    const nextY = () => {
-      const y = yCursor;
-      yCursor += 20;
-      return y;
-    };
+  const syncFromReka = React.useCallback(() => {
+    updatingFromRekaRef.current = true;
+
+    const page = store.activePage || store.addPage();
+    const existing: Record<string, any> = {};
+    page.children.forEach((el) => {
+      const tplId = (el as any).custom?.rekaTplId;
+      if (tplId) {
+        existing[tplId] = el;
+      }
+    });
+
+    const activeTplIds = new Set<string>();
 
     const renderView = (v: t.View) => {
       if (v.type === 'TagView') {
         const props = (v as any).props || {};
-        if (v.tag === 'text') {
-          page.addElement({
-            type: 'text',
-            text: String(props.value ?? ''),
-            x: 0,
-            y: nextY(),
-            fill: props.color ?? 'black',
-            fontSize: props.fontSize ?? 16,
-            custom: { rekaTplId: v.template.id },
-          });
-        } else if (v.tag === 'rect') {
-          page.addElement({
-            type: 'figure',
-            subType: 'rect',
-            x: props.x ?? 0,
-            y: props.y ?? 0,
-            width: props.width ?? 0,
-            height: props.height ?? 0,
-            fill: props.color ?? 'black',
-            custom: { rekaTplId: v.template.id },
-          });
+        const tplId = v.template.id;
+        activeTplIds.add(tplId);
+        let el = existing[tplId];
+
+        if (!el) {
+          if (v.tag === 'text') {
+            el = page.addElement({
+              type: 'text',
+              text: String(props.value ?? ''),
+              x: props.x ?? 0,
+              y: props.y ?? 0,
+              fill: props.color ?? 'black',
+              fontSize: props.fontSize ?? 16,
+              custom: { rekaTplId: tplId },
+            });
+          } else if (v.tag === 'rect') {
+            el = page.addElement({
+              type: 'figure',
+              subType: 'rect',
+              x: props.x ?? 0,
+              y: props.y ?? 0,
+              width: props.width ?? 0,
+              height: props.height ?? 0,
+              fill: props.color ?? 'black',
+              custom: { rekaTplId: tplId },
+            });
+          }
         } else {
-          (v as any).children?.forEach(renderView);
+          el.set({
+            x: props.x ?? el.x,
+            y: props.y ?? el.y,
+            width: props.width ?? el.width,
+            height: props.height ?? el.height,
+            rotation: props.rotation ?? el.rotation,
+            visible: props.visible ?? el.visible,
+          });
+          if (v.tag === 'text') {
+            el.set({
+              text: String(props.value ?? ''),
+              fontSize: props.fontSize ?? el.fontSize,
+              fill: props.color ?? el.fill,
+            });
+          }
         }
       } else if (v.type === 'RekaComponentView' || v.type === 'ExternalComponentView') {
         (v as any).render.forEach(renderView);
-      } else if (
-        v.type === 'FrameView' ||
-        v.type === 'SlotView' ||
-        v.type === 'FragmentView'
-      ) {
+      } else if (v.type === 'FrameView' || v.type === 'SlotView' || v.type === 'FragmentView') {
         (v as any).children.forEach(renderView);
       }
     };
@@ -68,24 +87,32 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
     if (frame.view) {
       renderView(frame.view);
     }
+
+    // remove elements that no longer exist
+    page.children.slice().forEach((el) => {
+      const tplId = (el as any).custom?.rekaTplId;
+      if (tplId && !activeTplIds.has(tplId)) {
+        page.removeElement(el.id);
+      }
+    });
+
     updatingFromRekaRef.current = false;
   }, [frame]);
 
   React.useEffect(() => {
-    renderFrame();
+    syncFromReka();
 
     const unsubscribe = frame.listenToChangeset(() => {
       if (updatingFromPolotnoRef.current) return;
-      renderFrame();
+      syncFromReka();
     });
 
     return () => {
       unsubscribe();
     };
-  }, [frame, renderFrame]);
+  }, [frame, syncFromReka]);
 
   React.useEffect(() => {
-    if (!frame) return;
     const disposer = reaction(
       () =>
         store.activePage?.children.map((el) => ({
@@ -105,41 +132,29 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
         if (updatingFromRekaRef.current) return;
         updatingFromPolotnoRef.current = true;
         frame.reka.change(() => {
+          const appComponent = frame.reka.state.program.components.find(
+            (c) => c.name === frame.componentName
+          );
+          const rootTpl = appComponent?.template as t.TagTemplate | undefined;
+          const seen = new Set<string>();
+
           elements.forEach((el) => {
             let tpl =
-              el.rekaTplId &&
-              frame.reka.getNodeFromId(el.rekaTplId, t.TagTemplate);
-            const appComponent = frame.reka.state.program.components.find(
-              (c) => c.name === frame.componentName
-            );
-            const rootTpl = appComponent?.template as t.TagTemplate | undefined;
+              el.rekaTplId && frame.reka.getNodeFromId(el.rekaTplId, t.TagTemplate);
 
-            if (!tpl) {
-              if (!rootTpl) return;
+            if (!tpl && rootTpl) {
               if (el.type === 'text') {
                 tpl = t.tagTemplate({
-                  id: el.rekaTplId,
                   tag: 'text',
-                  props: {
-                    value: t.literal({ value: el.text ?? '' }),
-                  },
+                  props: { value: t.literal({ value: el.text ?? '' }) },
                   children: [],
                 });
               } else if (el.type === 'figure' && el.subType === 'rect') {
-                tpl = t.tagTemplate({
-                  id: el.rekaTplId,
-                  tag: 'rect',
-                  props: {},
-                  children: [],
-                });
+                tpl = t.tagTemplate({ tag: 'rect', props: {}, children: [] });
               }
-
               if (tpl) {
                 rootTpl.children.push(tpl);
-                (el as any).custom = {
-                  ...(el as any).custom,
-                  rekaTplId: tpl.id,
-                };
+                (el as any).custom = { ...(el as any).custom, rekaTplId: tpl.id };
               }
             }
 
@@ -149,14 +164,8 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
               ...tpl.props,
               x: t.literal({ value: el.x }),
               y: t.literal({ value: el.y }),
-              width:
-                el.width !== undefined
-                  ? t.literal({ value: el.width })
-                  : tpl.props?.width,
-              height:
-                el.height !== undefined
-                  ? t.literal({ value: el.height })
-                  : tpl.props?.height,
+              width: el.width !== undefined ? t.literal({ value: el.width }) : tpl.props?.width,
+              height: el.height !== undefined ? t.literal({ value: el.height }) : tpl.props?.height,
               rotation:
                 el.rotation !== undefined
                   ? t.literal({ value: el.rotation })
@@ -166,18 +175,24 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
                   ? t.literal({ value: el.visible })
                   : tpl.props?.visible,
             };
-
             if (tpl.tag === 'text') {
               tpl.props = {
                 ...tpl.props,
                 value: t.literal({ value: el.text ?? '' }),
-              };
+                fontSize:
+                  el.fontSize !== undefined ? t.literal({ value: el.fontSize }) : tpl.props?.fontSize,
+              } as any;
             }
+            seen.add(tpl.id);
           });
+
+          if (rootTpl) {
+            rootTpl.children = rootTpl.children.filter((child) => seen.has(child.id));
+          }
         });
         updatingFromPolotnoRef.current = false;
       },
-      { equals: comparer.structural }
+      { fireImmediately: true, equals: comparer.structural }
     );
     return () => disposer();
   }, [frame]);

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -22,20 +22,21 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
     const page = store.activePage || store.addPage();
     const existing: Record<string, any> = {};
     page.children.forEach((el) => {
-      const tplId = (el as any).custom?.rekaTplId;
-      if (tplId) {
-        existing[tplId] = el;
+      const viewKey = (el as any).custom?.rekaViewKey;
+      if (viewKey) {
+        existing[viewKey] = el;
       }
     });
 
-    const activeTplIds = new Set<string>();
+    const activeViewKeys = new Set<string>();
 
     const renderView = (v: t.View) => {
       if (v.type === 'TagView') {
         const props = (v as any).props || {};
         const tplId = v.template.id;
-        activeTplIds.add(tplId);
-        let el = existing[tplId];
+        const viewKey = (v as any).key ?? tplId;
+        activeViewKeys.add(viewKey);
+        let el = existing[viewKey];
 
         if (!el) {
           if (v.tag === 'text') {
@@ -46,7 +47,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
               y: props.y ?? 0,
               fill: props.color ?? 'black',
               fontSize: props.fontSize ?? 16,
-              custom: { rekaTplId: tplId },
+              custom: { rekaTplId: tplId, rekaViewKey: viewKey },
             });
           } else if (v.tag === 'rect') {
             el = page.addElement({
@@ -57,7 +58,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
               width: props.width ?? 0,
               height: props.height ?? 0,
               fill: props.color ?? 'black',
-              custom: { rekaTplId: tplId },
+              custom: { rekaTplId: tplId, rekaViewKey: viewKey },
             });
           }
         } else {
@@ -76,10 +77,24 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
               fill: props.color ?? el.fill,
             });
           }
+          el.set({
+            custom: {
+              ...(el as any).custom,
+              rekaTplId: tplId,
+              rekaViewKey: viewKey,
+            },
+          });
         }
-      } else if (v.type === 'RekaComponentView' || v.type === 'ExternalComponentView') {
+      } else if (
+        v.type === 'RekaComponentView' ||
+        v.type === 'ExternalComponentView'
+      ) {
         (v as any).render.forEach(renderView);
-      } else if (v.type === 'FrameView' || v.type === 'SlotView' || v.type === 'FragmentView') {
+      } else if (
+        v.type === 'FrameView' ||
+        v.type === 'SlotView' ||
+        v.type === 'FragmentView'
+      ) {
         (v as any).children.forEach(renderView);
       }
     };
@@ -90,8 +105,8 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
 
     // remove elements that no longer exist
     page.children.slice().forEach((el) => {
-      const tplId = (el as any).custom?.rekaTplId;
-      if (tplId && !activeTplIds.has(tplId)) {
+      const viewKey = (el as any).custom?.rekaViewKey;
+      if (viewKey && !activeViewKeys.has(viewKey)) {
         page.removeElement(el.id);
       }
     });
@@ -156,12 +171,17 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
                   props: { value: t.literal({ value: snapshot.text ?? '' }) },
                   children: [],
                 });
-              } else if (snapshot.type === 'figure' && snapshot.subType === 'rect') {
+              } else if (
+                snapshot.type === 'figure' &&
+                snapshot.subType === 'rect'
+              ) {
                 tpl = t.tagTemplate({ tag: 'rect', props: {}, children: [] });
               }
               if (tpl) {
                 rootTpl.children.push(tpl);
-                el.set({ custom: { ...(el as any).custom, rekaTplId: tpl.id } });
+                el.set({
+                  custom: { ...(el as any).custom, rekaTplId: tpl.id },
+                });
               }
             }
 
@@ -204,12 +224,14 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
           });
 
           if (rootTpl) {
-            rootTpl.children = rootTpl.children.filter((child) => seen.has(child.id));
+            rootTpl.children = rootTpl.children.filter((child) =>
+              seen.has(child.id)
+            );
           }
         });
         updatingFromPolotnoRef.current = false;
       },
-      { fireImmediately: true, equals: comparer.structural }
+      { fireImmediately: false, equals: comparer.structural }
     );
     return () => disposer();
   }, [frame]);

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -124,7 +124,9 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
 
     const unsubscribe = frame.listenToChangeset(() => {
       if (updatingFromPolotnoRef.current) return;
-      syncFromReka();
+      frame.compute(true, () => {
+        syncFromReka();
+      });
     });
 
     return () => {

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -15,57 +15,46 @@ export type PolotnoRendererProps = {
 export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
   const updatingFromRekaRef = React.useRef(false);
   const updatingFromPolotnoRef = React.useRef(false);
-  const idMapRef = React.useRef(new Map<string, string>()); // polotnoId -> tplId
 
   const syncFromReka = React.useCallback(() => {
     updatingFromRekaRef.current = true;
 
     const page = store.activePage || store.addPage();
-    const existing: Record<string, any> = {};
-    page.children.forEach((el) => {
-      const viewKey = (el as any).custom?.rekaViewKey;
-      if (viewKey) {
-        existing[viewKey] = el;
-      }
-    });
-
-    const activeViewKeys = new Set<string>();
+    const activeIds = new Set<string>();
 
     const renderView = (v: t.View) => {
       if (v.type === 'TagView') {
         const props = (v as any).props || {};
         const tplId = v.template.id;
-        const viewKey = (v as any).key ?? tplId;
 
         if (v.tag === 'text' || v.tag === 'rect') {
-          activeViewKeys.add(viewKey);
-          let el = existing[viewKey];
+          activeIds.add(tplId);
+          let el = page.children.find((c) => c.id === tplId);
 
           if (!el) {
             if (v.tag === 'text') {
               el = page.addElement({
                 type: 'text',
+                id: tplId,
                 text: String(props.value ?? ''),
                 x: props.x ?? 0,
                 y: props.y ?? 0,
                 fill: props.color ?? 'black',
                 fontSize: props.fontSize ?? 16,
-                custom: { rekaTplId: tplId, rekaViewKey: viewKey },
+                custom: { rekaTplId: tplId },
               });
             } else if (v.tag === 'rect') {
               el = page.addElement({
                 type: 'figure',
                 subType: 'rect',
+                id: tplId,
                 x: props.x ?? 0,
                 y: props.y ?? 0,
                 width: props.width ?? 0,
                 height: props.height ?? 0,
                 fill: props.color ?? 'black',
-                custom: { rekaTplId: tplId, rekaViewKey: viewKey },
+                custom: { rekaTplId: tplId },
               });
-            }
-            if (el) {
-              idMapRef.current.set(el.id, tplId);
             }
           } else {
             el.set({
@@ -87,14 +76,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
                 fill: props.color ?? el.fill,
               });
             }
-            el.set({
-              custom: {
-                ...(el as any).custom,
-                rekaTplId: tplId,
-                rekaViewKey: viewKey,
-              },
-            });
-            idMapRef.current.set(el.id, tplId);
+            el.set({ custom: { ...(el as any).custom, rekaTplId: tplId } });
           }
         } else {
           (v as any).children?.forEach(renderView);
@@ -119,10 +101,9 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
 
     // remove elements that no longer exist
     page.children.slice().forEach((el) => {
-      const viewKey = (el as any).custom?.rekaViewKey;
-      if (viewKey && !activeViewKeys.has(viewKey)) {
+      const tplId = (el as any).custom?.rekaTplId;
+      if (tplId && !activeIds.has(tplId)) {
         store.deleteElements([el.id]);
-        idMapRef.current.delete(el.id);
       }
     });
 
@@ -164,7 +145,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
             visible: el.visible,
             fill: (el as any).fill,
             fontSize: (el as any).fontSize,
-            rekaTplId: idMapRef.current.get(el.id) || (el as any).custom?.rekaTplId,
+            rekaTplId: (el as any).custom?.rekaTplId,
           },
         })),
       (elements) => {
@@ -177,16 +158,9 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
           const rootTpl = appComponent?.template as t.TagTemplate | undefined;
           const seen = new Set<string>();
 
-          const usedTplIds = new Set<string>();
-          const nextMap = new Map<string, string>();
-
           elements.forEach(({ el, snapshot }) => {
-            const mappedId = idMapRef.current.get(snapshot.id);
-            let tplId = mappedId || snapshot.rekaTplId;
-            let tpl =
-              tplId && !usedTplIds.has(tplId)
-                ? frame.reka.getNodeFromId(tplId, t.TagTemplate)
-                : undefined;
+            const tplId = snapshot.id;
+            let tpl = frame.reka.getNodeFromId(tplId, t.TagTemplate);
 
             if (!tpl && rootTpl) {
               if (snapshot.type === 'text') {
@@ -223,9 +197,6 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
             }
 
             if (!tpl) return;
-
-            usedTplIds.add(tpl.id);
-            nextMap.set(snapshot.id, tpl.id);
 
             tpl.props = {
               ...tpl.props,
@@ -289,7 +260,6 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
             Object.keys(rootTpl.slots).forEach((slot) => {
               rootTpl.slots[slot] = rootTpl.slots[slot].filter(prune);
             });
-            idMapRef.current = nextMap;
           }
         });
         updatingFromPolotnoRef.current = false;

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -129,9 +129,11 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
     syncFromReka();
 
     const unsubscribe = frame.listenToChangeset(() => {
-      if (updatingFromPolotnoRef.current) return;
+      const fromPolotno = updatingFromPolotnoRef.current;
       frame.compute(true, () => {
-        syncFromReka();
+        if (!fromPolotno) {
+          syncFromReka();
+        }
       });
     });
 

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -166,5 +166,5 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
     return () => disposer();
   }, [frame]);
 
-  return <Workspace store={store} />;
+  return <Workspace style={{ width: '100%', height: '100%' }} store={store} />;
 });

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -112,7 +112,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
     page.children.slice().forEach((el) => {
       const viewKey = (el as any).custom?.rekaViewKey;
       if (viewKey && !activeViewKeys.has(viewKey)) {
-        page.removeElement(el.id);
+        store.deleteElements([el.id]);
       }
     });
 

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -15,6 +15,7 @@ export type PolotnoRendererProps = {
 export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
   const updatingFromRekaRef = React.useRef(false);
   const updatingFromPolotnoRef = React.useRef(false);
+  const idMapRef = React.useRef(new Map<string, string>()); // polotnoId -> tplId
 
   const syncFromReka = React.useCallback(() => {
     updatingFromRekaRef.current = true;
@@ -63,6 +64,9 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
                 custom: { rekaTplId: tplId, rekaViewKey: viewKey },
               });
             }
+            if (el) {
+              idMapRef.current.set(el.id, tplId);
+            }
           } else {
             el.set({
               x: props.x ?? el.x,
@@ -86,6 +90,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
                 rekaViewKey: viewKey,
               },
             });
+            idMapRef.current.set(el.id, tplId);
           }
         } else {
           (v as any).children?.forEach(renderView);
@@ -113,6 +118,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
       const viewKey = (el as any).custom?.rekaViewKey;
       if (viewKey && !activeViewKeys.has(viewKey)) {
         store.deleteElements([el.id]);
+        idMapRef.current.delete(el.id);
       }
     });
 
@@ -150,7 +156,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
             height: el.height,
             rotation: el.rotation,
             visible: el.visible,
-            rekaTplId: (el as any).custom?.rekaTplId,
+            rekaTplId: idMapRef.current.get(el.id) || (el as any).custom?.rekaTplId,
           },
         })),
       (elements) => {
@@ -164,12 +170,15 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
           const seen = new Set<string>();
 
           const usedTplIds = new Set<string>();
+          const nextMap = new Map<string, string>();
 
           elements.forEach(({ el, snapshot }) => {
+            const mappedId = idMapRef.current.get(snapshot.id);
+            let tplId = mappedId || snapshot.rekaTplId;
             let tpl =
-              snapshot.rekaTplId &&
-              !usedTplIds.has(snapshot.rekaTplId) &&
-              frame.reka.getNodeFromId(snapshot.rekaTplId, t.TagTemplate);
+              tplId && !usedTplIds.has(tplId)
+                ? frame.reka.getNodeFromId(tplId, t.TagTemplate)
+                : undefined;
 
             if (!tpl && rootTpl) {
               if (snapshot.type === 'text') {
@@ -195,6 +204,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
             if (!tpl) return;
 
             usedTplIds.add(tpl.id);
+            nextMap.set(snapshot.id, tpl.id);
 
             tpl.props = {
               ...tpl.props,
@@ -254,6 +264,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
             Object.keys(rootTpl.slots).forEach((slot) => {
               rootTpl.slots[slot] = rootTpl.slots[slot].filter(prune);
             });
+            idMapRef.current = nextMap;
           }
         });
         updatingFromPolotnoRef.current = false;

--- a/examples/01-react/src/components/PolotnoRenderer/index.tsx
+++ b/examples/01-react/src/components/PolotnoRenderer/index.tsx
@@ -14,7 +14,8 @@ export type PolotnoRendererProps = {
 
 export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
   const updatingFromRekaRef = React.useRef(false);
-  React.useEffect(() => {
+  const updatingFromPolotnoRef = React.useRef(false);
+  const renderFrame = React.useCallback(() => {
     updatingFromRekaRef.current = true;
     store.clear();
     const page = store.addPage();
@@ -68,7 +69,20 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
       renderView(frame.view);
     }
     updatingFromRekaRef.current = false;
-  }, [frame.view]);
+  }, [frame]);
+
+  React.useEffect(() => {
+    renderFrame();
+
+    const unsubscribe = frame.listenToChangeset(() => {
+      if (updatingFromPolotnoRef.current) return;
+      renderFrame();
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [frame, renderFrame]);
 
   React.useEffect(() => {
     if (!frame) return;
@@ -89,6 +103,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
         })),
       (elements) => {
         if (updatingFromRekaRef.current) return;
+        updatingFromPolotnoRef.current = true;
         frame.reka.change(() => {
           elements.forEach((el) => {
             let tpl =
@@ -160,6 +175,7 @@ export const PolotnoRenderer = observer(({ frame }: PolotnoRendererProps) => {
             }
           });
         });
+        updatingFromPolotnoRef.current = false;
       },
       { equals: comparer.structural }
     );

--- a/examples/01-react/src/pages/polotno.tsx
+++ b/examples/01-react/src/pages/polotno.tsx
@@ -120,7 +120,7 @@ export default function PolotnoPage() {
         <div className="w-3/6 h-full border-r-2">
           <Editor />
         </div>
-        <div className="flex-1 flex items-center justify-center">
+        <div className="flex-1 h-full flex items-center justify-center">
           <PolotnoView />
         </div>
       </div>

--- a/examples/01-react/src/pages/polotno.tsx
+++ b/examples/01-react/src/pages/polotno.tsx
@@ -110,7 +110,7 @@ const frame = reka.createFrame({
 frame.compute(true);
 
 const PolotnoView = observer(() => {
-  return frame.view ? <PolotnoRenderer view={frame.view} /> : null;
+  return <PolotnoRenderer frame={frame} />;
 });
 
 export default function PolotnoPage() {


### PR DESCRIPTION
## Summary
- update Polotno renderer to track template IDs when creating Polotno elements
- watch Polotno store changes and write back to Reka state
- update example page to pass the frame rather than a view

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685984849a7c832c92e124138e975429